### PR TITLE
Add knockd port-knocking proof of concept

### DIFF
--- a/POC1/README.md
+++ b/POC1/README.md
@@ -1,0 +1,43 @@
+# POC1 – knockd demonstration
+
+This miniature project shows how a server can hide an SSH service behind a
+port‑knocking door. A three‑step sequence (8881, 7777, 9991) briefly opens
+port **2222**, letting the user try an SSH connection before the door shuts
+again thirty seconds later.
+
+```
+client -> knocks -> server -> port open -> SSH
+```
+
+## Components
+
+- **setup_knockd.sh** – configures the server, writes `/etc/knockd.conf`, sets
+  up iptables and restarts the daemon.
+- **knock_client.py** – sends the knock sequence, waits, checks the port and can
+  optionally close it again.
+
+Both scripts are heavily commented so they can be dropped straight into a lab
+report or exam presentation.
+
+## Quick start
+
+1. On the server, run:
+   ```bash
+   sudo ./setup_knockd.sh
+   ```
+2. From a client machine:
+   ```bash
+   python3 knock_client.py --host <SERVER_IP> --port 2222 --close
+   ```
+   The `--close` flag sends the reverse sequence after testing.
+
+The client logs its actions in `knockd_demo.log` and prints a minimalist
+"hacker style" output to the terminal.
+
+## Limitations
+
+- Intended for IPv4 networks and ephemeral lab setups.
+- Uses simple TCP connection attempts; no packet crafting or authentication.
+- Adjust the iptables commands if another firewall is in use.
+
+Enjoy exploring the basics of port‑knocking!

--- a/POC1/knock_client.py
+++ b/POC1/knock_client.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""
+knock_client.py - simple client for the knockd proof of concept.
+
+This script sends a predefined sequence of TCP connection attempts to a
+remote host. If the server is configured with knockd, the sequence will
+temporarily open the SSH service on port 2222. The script then checks the
+port and reports whether the connection succeeded. It can also send the
+reverse sequence to close the port again.
+
+The code is intentionally verbose and heavily commented so it can be used
+for demonstrations, lab reports or exam presentations.
+"""
+
+import argparse                      # Parse command-line arguments
+import logging                       # Write events to a log file
+import socket                        # Create TCP connection attempts
+import sys                           # Provide access to stdout for fancy output
+import time                          # Insert small pauses between knocks
+
+# --------------------------- logging setup ---------------------------------
+logger = logging.getLogger("knockd_demo")    # Name of the logger
+logger.setLevel(logging.INFO)                # Log only informative messages
+handler = logging.FileHandler("knockd_demo.log")  # Log file name
+fmt = logging.Formatter("%(asctime)s %(message)s") # Timestamped format
+handler.setFormatter(fmt)                    # Apply format to handler
+logger.addHandler(handler)                   # Add handler to logger
+
+# --------------------------- utility functions -----------------------------
+def knock(host: str, port: int) -> None:
+    """Send a single TCP SYN to the target host and port."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  # Build TCP socket
+    sock.settimeout(0.5)                # Do not wait too long for responses
+    try:
+        sock.connect((host, port))      # Attempt connection
+    except Exception:
+        pass                            # Ignore errors; knockd only needs the SYN
+    finally:
+        sock.close()                    # Always close the socket
+
+def check_port(host: str, port: int) -> bool:
+    """Return True if the TCP port appears open, False otherwise."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)  # Build TCP socket
+    sock.settimeout(2)                 # Two-second timeout for the test
+    result = sock.connect_ex((host, port))  # 0 means success
+    sock.close()                       # Clean up
+    return result == 0                 # Convert numeric code to boolean
+
+# --------------------------- argument parsing ------------------------------
+parser = argparse.ArgumentParser(description="Knock then test an SSH port")
+parser.add_argument("--host", required=True, help="IP address of the server")
+parser.add_argument("--port", type=int, default=2222, help="SSH port to verify")
+parser.add_argument("--close", action="store_true", help="Send reverse sequence")
+args = parser.parse_args()             # Read arguments into 'args'
+
+OPEN_SEQ = [8881, 7777, 9991]          # Sequence to open the port
+CLOSE_SEQ = [9991, 7777, 8881]         # Sequence to close the port
+
+# ------------------------------ main routine -------------------------------
+for p in OPEN_SEQ:                     # Iterate over the opening sequence
+    sys.stdout.write(f"[>] Knocking {p}\n")  # Pretty output with no buffering
+    sys.stdout.flush()                 # Force immediate display
+    logger.info("knock %s", p)         # Log the knock
+    knock(args.host, p)                # Fire the knock packet
+    time.sleep(0.5)                    # Short pause between knocks
+
+sys.stdout.write("[*] Waiting for the door to open...\n")
+sys.stdout.flush()
+time.sleep(3)                          # Allow knockd to open the port
+
+if check_port(args.host, args.port):   # Test if the SSH port is open
+    sys.stdout.write(f"[+] Port {args.port} is open!\n")
+    logger.info("port %s open", args.port)
+else:
+    sys.stdout.write(f"[-] Port {args.port} is still closed.\n")
+    logger.info("port %s closed", args.port)
+
+if args.close:                         # Optionally send closing sequence
+    sys.stdout.write("[*] Sending closing sequence...\n")
+    sys.stdout.flush()
+    for p in CLOSE_SEQ:                # Iterate over closing ports
+        sys.stdout.write(f"[<] Knocking {p}\n")
+        sys.stdout.flush()
+        logger.info("close %s", p)     # Log the closing knock
+        knock(args.host, p)            # Send knock
+        time.sleep(0.5)
+
+logger.info("done")                    # Log completion of the script

--- a/POC1/setup_knockd.sh
+++ b/POC1/setup_knockd.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+#  Script : setup_knockd.sh
+#  Purpose: Configure knockd so that a three-port sequence opens SSH on 2222
+#           for thirty seconds. Intended for demonstrations and lab work.
+#  Usage  : sudo ./setup_knockd.sh
+#  Notes  : This script modifies /etc/knockd.conf and iptables rules.
+#           Run it only on a test machine.
+# ---------------------------------------------------------------------------
+
+set -e                                          # Stop immediately on errors
+
+if [[ $EUID -ne 0 ]]; then                      # Make sure we are root
+    echo "[!] Run this script as root."       # Warn the user
+    exit 1                                      # Abort if not root
+fi
+
+echo "[+] Installing knockd..."               # Install knockd package
+apt-get update -y >/dev/null                    # Refresh package index
+apt-get install -y knockd >/dev/null            # Install knockd silently
+
+echo "[+] Writing /etc/knockd.conf..."        # Create knockd configuration
+cat >/etc/knockd.conf <<'KNOCKEOF'               # Start here-document
+[options]
+    UseSyslog
+
+[openSSH]
+    sequence      = 8881,7777,9991
+    seq_timeout   = 5
+    command       = /sbin/iptables -I INPUT -s %IP% -p tcp --dport 2222 -j ACCEPT
+    cmd_timeout   = 30
+    tcpflags      = syn
+
+[closeSSH]
+    sequence      = 9991,7777,8881
+    seq_timeout   = 5
+    command       = /sbin/iptables -D INPUT -s %IP% -p tcp --dport 2222 -j ACCEPT
+    tcpflags      = syn
+KNOCKEOF
+
+echo "[+] Setting default firewall rule: DROP TCP 2222..."  # Block 2222 by default
+iptables -D INPUT -p tcp --dport 2222 -j DROP 2>/dev/null || true  # Remove old rule if any
+iptables -I INPUT -p tcp --dport 2222 -j DROP                    # Insert new DROP rule
+
+cleanup() {                                                      # Function to restore firewall
+    echo "[+] Cleaning up: removing DROP rule on port 2222."  # Inform user during cleanup
+    iptables -D INPUT -p tcp --dport 2222 -j DROP 2>/dev/null || true  # Remove rule safely
+}
+trap cleanup EXIT                                                # Register cleanup for script exit
+
+echo "[+] Restarting knockd service..."                        # Restart knockd
+systemctl enable knockd >/dev/null                               # Ensure service starts at boot
+systemctl restart knockd                                         # Restart service now
+
+echo "[+] Checking that knockd is listening..."                # Verify knockd is running
+sleep 1                                                          # Short pause
+ss -lunpt | grep knockd || echo "[!] knockd not listening!"   # Display listening socket
+
+echo "[+] Setup complete. Use the client to knock."            # Final message


### PR DESCRIPTION
## Summary
- Add `setup_knockd.sh` to configure knockd to open SSH port 2222 with a three-port sequence
- Provide `knock_client.py` to send knocks and optionally close the port, logging actions
- Document usage and limitations in `POC1/README.md`

