### PR TITLE
feat: improve timing-based SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,17 @@ Si la séquence est correcte, le serveur ajoute temporairement une règle
 pip3 install scapy
 ```
 
+## Tests POC5
+
+```bash
+# auto-test du décodage
+sudo python3 poc5/poc5_server_timing.py --selftest
+
+# client sans émission (aperçu des bits)
+sudo python3 poc5/poc5_client_timing.py 127.0.0.1 --dry-run
+
+# boucle locale
+sudo python3 poc5/poc5_server_timing.py --iface lo &
+sudo python3 poc5/poc5_client_timing.py 127.0.0.1
+```
+

--- a/poc5/poc5_client_timing.py
+++ b/poc5/poc5_client_timing.py
@@ -76,6 +76,7 @@ def main():
     ap.add_argument("--d1", type=float, default=None)
     ap.add_argument("--iface", default=None)
     ap.add_argument("--no-ssh", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
     args=ap.parse_args()
 
     if args.d0 is None or args.d1 is None:
@@ -90,6 +91,9 @@ def main():
     wire=build_wire(aes,mac,args.duration); bits=build_frame(wire)
 
     LOG("INFO", target=dst_ip, bytes=len(wire), bits=len(bits), d0=d0, d1=d1, profile=args.profile)
+    if args.dry_run:
+        LOG("DRY", bits="".join(str(b) for b in bits[:32]))
+        return
     send_timing(bits, dst_ip, d0, d1, iface=args.iface)
 
     if not args.no_ssh:


### PR DESCRIPTION
## Summary
- derive timing threshold from preamble for robust decoding and scan all candidates
- add self-test mode and switch to pcap timestamps
- support client dry-run and document test plan
